### PR TITLE
Use a dict for the *db* value in newer versions of Shen.

### DIFF
--- a/modulesys.shen
+++ b/modulesys.shen
@@ -36,7 +36,7 @@
 
 (set *paths* [])
 (set *list* [])
-(set *db* (vector 256))
+(set *db* (trap-error (shen.dict 256) (/. _ (vector 256))))
 (set *fields* [path load translate depends translate-depends load-fn unload-fn
                translate-fn])
 


### PR DESCRIPTION
In newer versions of the Shen kernel put/get stores are implemented as dicts instead of vectors.

This change makes the store used by modulesys work in both older and newer versions by trying to construct a dict first and falling back to a vector if that doesn't work.